### PR TITLE
pin XSPRESS3 to commit 0e8eb4ba

### DIFF
--- a/INSTALL_CONFIG
+++ b/INSTALL_CONFIG
@@ -33,7 +33,7 @@ DEVIOCSTATS      master               $(SUPPORT)/iocStats                      i
 SCALER           master               $(SUPPORT)/scaler                        scaler                   YES              YES              YES
 SSCAN            R2-11-3              $(SUPPORT)/sscan                         sscan                    YES              YES              YES
 IPUNIDIG         R2-12                $(SUPPORT)/ipUnidig                      ipUnidig                 YES              YES              YES
-XSPRESS3         master               $(SUPPORT)/xspress3                      xspress3                 YES              YES              YES
+XSPRESS3         0e8eb4ba             $(SUPPORT)/xspress3                      xspress3                 YES              YES              YES
 QUADEM           R9-4                 $(SUPPORT)/quadEM                        quadEM                   YES              YES              YES
 CAPUTLOG         R3.7                 $(SUPPORT)/caPutLog                      caPutLog                 YES              YES              YES
 STD              R3-6-2               $(SUPPORT)/std                           std                      YES              YES              YES


### PR DESCRIPTION
While setting up an Xspress3 IOC from the [master branch](https://github.com/epics-modules/xspress3) at TES it was discovered that an extra frame was acquired upon setting the acquire PV when in TTL_VETO_ONLY mode. This issue was not observed at SRX which was using the older commit 0e8eb4ba. This commit worked correctly at TES and so we are pinning to it until the problem is resolved on the master branch.

For reference:
```
commit 0e8eb4ba188d8ebb125d7045db11de5c4c86a37c
Merge: cfc9c43 944de93
Author: Matt Newville <newville@cars.uchicago.edu>
Date:   Thu Aug 25 14:31:54 2022 -0500

    Merge pull request #36 from oksanagit/add_iocStats

    Addin iocStats module to the common file loaded by all IOCs
```

The issue with the Xspress3 AreaDetector has been [reported](https://github.com/epics-modules/xspress3/issues/46).